### PR TITLE
chore: use only crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,12 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,8 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
-source = "git+https://github.com/itsjunetime/ratatui.git#a3fd887eaafa13faf88f28b27df94a5eb6051933"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
@@ -1555,22 +1550,23 @@ dependencies = [
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "ratatui-image"
-version = "2.0.1"
-source = "git+https://github.com/itsjunetime/ratatui-image.git?branch=vb64_on_personal#5a11b825425932c6553abe967206e0bf76256f79"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a07161c498ddd5066a444a869f27fd97cfc164dbee8c0bdb5ff803b8bb54ce"
 dependencies = [
- "base64 0.22.1",
- "dyn-clone",
+ "base64 0.21.7",
  "icy_sixel",
  "image",
  "rand",
  "ratatui",
  "rustix",
- "vb64",
+ "thiserror",
+ "windows",
 ]
 
 [[package]]
@@ -1905,6 +1901,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,7 +2175,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -2169,15 +2185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vb64"
-version = "0.1.2"
-source = "git+https://github.com/lukaslihotzki/vb64?rev=f48cf02c06a29a48ddf9efa684bdc904b3b5370d#f48cf02c06a29a48ddf9efa684bdc904b3b5370d"
 
 [[package]]
 name = "version-compare"
@@ -2311,6 +2328,70 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,25 @@ name = "tdf"
 name = "tdf"
 
 [dependencies]
-poppler-rs = { version = "0.24.1", default-features = false, features = ["v23_7"] }
+poppler-rs = { version = "0.24.1", default-features = false, features = [
+    "v23_7",
+] }
 cairo-rs = { version = "0.20.0", default-features = false, features = ["png"] }
 # we're using this branch because it has significant performance fixes that I'm waiting on responses from the upstream devs to get upstreamed. See https://github.com/ratatui-org/ratatui/issues/1116
-ratatui = { git = "https://github.com/itsjunetime/ratatui.git" }
+# ratatui = { git = "https://github.com/itsjunetime/ratatui.git" }
+ratatui = { version = "0.29.0" }
 # ratatui = { path = "./ratatui" }
 # We're using this to have the vb64 feature (for faster base64 encoding, since that does take up a good bit of time when converting images to the Box<dyn ratatui_image::Protocol>. It also just includes a few more features that I'm waiting on main to upstream
-ratatui-image = { git = "https://github.com/itsjunetime/ratatui-image.git", branch = "vb64_on_personal", features = ["rustix", "vb64"], default-features = false }
-# ratatui-image = { path = "./ratatui-image", features = ["rustix", "vb64"], default-features = false }
+# ratatui-image = { git = "https://github.com/itsjunetime/ratatui-image.git", branch = "vb64_on_personal", features = ["rustix", "vb64"], default-features = false }
+ratatui-image = { version = "3.0", features = [
+    # "rustix",
+    # "vb64",
+], default-features = false }
 crossterm = { version = "0.28.1", features = ["event-stream"] }
-image = { version = "0.25.1", features = ["png", "rayon"], default-features = false }
+image = { version = "0.25.1", features = [
+    "png",
+    "rayon",
+], default-features = false }
 notify = { version = "7.0.0", features = ["crossbeam-channel"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
 futures-util = { version = "0.3.30", default-features = false }

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -98,8 +98,8 @@ pub fn start_converting_loop(
 	let (to_converter_tx, from_main_rx) = unbounded();
 	let (to_main_tx, from_converter_rx) = unbounded();
 
-	let mut picker = Picker::new(FONT_SIZE);
-	picker.protocol_type = ProtocolType::Kitty;
+	let mut picker = Picker::from_fontsize(FONT_SIZE);
+	picker.set_protocol_type(ProtocolType::Kitty);
 
 	tokio::spawn(run_conversion_loop(
 		to_main_tx,

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -7,7 +7,7 @@ use ratatui_image::{picker::Picker, protocol::Protocol, Resize};
 use crate::renderer::{fill_default, PageInfo, RenderError};
 
 pub struct ConvertedPage {
-	pub page: Box<dyn Protocol>,
+	pub page: Protocol,
 	pub num: usize,
 	pub num_results: usize
 }
@@ -67,7 +67,7 @@ pub async fn run_conversion_loop(
 		// size for the area given, so to save ratatui the work of having to
 		// resize it, we tell them to crop it to fit.
 		let txt_img = picker
-			.new_protocol(dyn_img, img_area, Resize::None)
+			.new_protocol(dyn_img, img_area, Resize::Fit(None))
 			.map_err(|e| {
 				RenderError::Render(format!(
 					"Couldn't convert DynamicImage to ratatui image: {e}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,11 +125,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// We need to create `picker` on this thread because if we create it on the `renderer` thread,
 	// it messes up something with user input. Input never makes it to the crossterm thing
-	let mut picker = Picker::new((
+	let picker = Picker::from_fontsize((
 		window_size.width / window_size.columns,
 		window_size.height / window_size.rows
 	));
-	picker.guess_protocol();
+	// picker.protocol_type(); // TODO: Had to get rid of this
 
 	// then we want to spawn off the rendering task
 	// We need to use the thread::spawn API so that this exists in a thread not owned by tokio,
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let backend = CrosstermBackend::new(std::io::stdout());
 	let mut term = Terminal::new(backend)?;
-	term.skip_diff(true);
+	// term.skip_diff(true); // TODO: Had to get rid of this
 
 	// poppler has some annoying logging (e.g. if you request a page index out-of-bounds of a
 	// document's pages, then it will return `None`, but still log to stderr with CRITICAL level),


### PR DESCRIPTION
## Notes
You mention in #10 that you want to do a release of this crate, which would be great! I also read through some of the issues you have which led you to pin to other versions of `ratatui` and `ratatui-image`. 

If we can get beyond that, then this could be published to crates.io instead (which would definitely be preferred by many). 

Running with these changes on my machine, I can't notice any poor performance, but there may be some issues with resizing my terminal. Using iTerm2 on MacOS.

## Tasks
- [x] Removes github uses of `ratty` and `ratatui-image`
- [ ] ???

## Discussion
I came about this because I've been building [learner](https://github.com/autoparallel/learner) as a means to have a nice database for research. Part of it can be seen as a replacement for things like Zotero, and I just set up a TUI with it and was hoping to use a TUI based PDF reader -- so I found this!

I'm curious if you'd also be interested in using `lopdf` instead of `popplers-rs`? This would be all Rust native and not have FFI to `popplers` bindings and I think would help this be more universally compatible.

---

I'm really happy to see this and help push it along! Let me know what I can do.