### PR TITLE
Custom Colors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfontconfig1-dev libgoogle-perftools-dev google-perftools
     - uses: actions/checkout@v4
+    - name: Install clippy and fmt
+      run: rustup component add clippy rustfmt
     - name: Clippy
       run: cargo clippy -- -D warnings
     - name: Check fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f9a16a848a7fb95dd47ce387ac1ee9a6df879ba784b815537fcd388a1a8288"
+dependencies = [
+ "phf",
+ "rgb",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2646,9 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rstest"
@@ -2988,6 +3001,7 @@ dependencies = [
  "cpuprofiler",
  "criterion",
  "crossterm",
+ "csscolorparser 0.7.0",
  "flume",
  "futures-util",
  "image",
@@ -3593,7 +3607,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
 dependencies = [
- "csscolorparser",
+ "csscolorparser 0.6.2",
  "deltae",
  "lazy_static",
  "wezterm-dynamic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f9a16a848a7fb95dd47ce387ac1ee9a6df879ba784b815537fcd388a1a8288"
 dependencies = [
  "phf",
- "rgb",
 ]
 
 [[package]]
@@ -2646,9 +2645,6 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "rstest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rayon = { version = "*", default-features = false }
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.4.0", optional = true }
+csscolorparser = { version = "0.7.0", features = ["rgb", "rust-rgb"] }
 
 [profile.production]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rayon = { version = "*", default-features = false }
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.4.0", optional = true }
-csscolorparser = { version = "0.7.0", features = ["rgb", "rust-rgb"] }
+csscolorparser = { version = "0.7.0" }
 
 [profile.production]
 inherits = "release"

--- a/benches/for_profiling.rs
+++ b/benches/for_profiling.rs
@@ -9,5 +9,5 @@ async fn main() {
 		.nth(1)
 		.expect("Please enter a file to profile");
 
-	utils::render_doc(file, None).await;
+	utils::render_doc(file, None, 0, 1000).await;
 }

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -57,7 +57,9 @@ pub struct RenderState {
 const FONT_SIZE: (u16, u16) = (8, 14);
 
 pub fn start_rendering_loop(
-	path: impl AsRef<Path>
+	path: impl AsRef<Path>,
+	black: i32,
+	white: i32
 ) -> (
 	RecvStream<'static, Result<RenderInfo, RenderError>>,
 	Sender<RenderNotif>
@@ -91,7 +93,9 @@ pub fn start_rendering_loop(
 			to_main_tx,
 			from_main_rx,
 			size,
-			tdf::PrerenderLimit::All
+			tdf::PrerenderLimit::All,
+			black,
+			white
 		)
 	});
 
@@ -122,8 +126,8 @@ pub fn start_converting_loop(
 	(from_converter_rx, to_converter_tx)
 }
 
-pub fn start_all_rendering(path: impl AsRef<Path>) -> RenderState {
-	let (from_render_rx, to_render_tx) = start_rendering_loop(path);
+pub fn start_all_rendering(path: impl AsRef<Path>, black: i32, white: i32) -> RenderState {
+	let (from_render_rx, to_render_tx) = start_rendering_loop(path, black, white);
 	let (from_converter_rx, to_converter_tx) = start_converting_loop(20);
 
 	let pages: Vec<Option<ConvertedPage>> = Vec::new();
@@ -137,14 +141,14 @@ pub fn start_all_rendering(path: impl AsRef<Path>) -> RenderState {
 	}
 }
 
-pub async fn render_doc(path: impl AsRef<Path>, search_term: Option<&str>) {
+pub async fn render_doc(path: impl AsRef<Path>, search_term: Option<&str>, black: i32, white: i32) {
 	let RenderState {
 		mut from_render_rx,
 		mut from_converter_rx,
 		mut pages,
 		mut to_converter_tx,
 		to_render_tx
-	} = start_all_rendering(path);
+	} = start_all_rendering(path, black, white);
 
 	if let Some(term) = search_term {
 		to_render_tx

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use crossterm::{
 		enable_raw_mode, window_size
 	}
 };
-use csscolorparser;
 use futures_util::{FutureExt, stream::StreamExt};
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 use ratatui::{Terminal, backend::CrosstermBackend};

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,5 @@ fn on_notify_ev(
 fn parse_color_to_i32(cs: &str) -> Result<i32, csscolorparser::ParseColorError> {
 	let color = csscolorparser::parse(cs)?;
 	let [r, g, b, _] = color.to_rgba8();
-	let u: u32 = u32::from(r) * 256 * 256 + u32::from(g) * 256 + u32::from(b);
-	let bytes = u.to_le_bytes();
-	Ok(i32::from_le_bytes(bytes))
+	Ok(i32::from_be_bytes([0, r, g, b]))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		/// The number of pages to prerender surrounding the currently-shown page; 0 means no
 		/// limit. By default, there is no limit.
 		optional -p,--prerender prerender: usize
-		/// Custom white and black colors
+		/// Custom white color
 		optional -w,--white-color white: String
+		/// Custom black color
 		optional -b,--black-color black: String
 		/// PDF file to read
 		required file: PathBuf

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	};
 
 	let path = flags.file.canonicalize()?;
-	let black = parse_color_to_i32(&flags.black_color.unwrap_or("000000".into()))
-		.map_err(|e| BadTermSizeStdin(format!("Couldn't parse black color: {e} - is it formatted like a CSS color?")))?;
+	let black = parse_color_to_i32(&flags.black_color.unwrap_or("000000".into())).map_err(|e| {
+		BadTermSizeStdin(format!(
+			"Couldn't parse black color: {e} - is it formatted like a CSS color?"
+		))
+	})?;
 
-	let white = parse_color_to_i32(&flags.white_color.unwrap_or("FFFFFF".into()))
-		.map_err(|e| BadTermSizeStdin(format!("Couldn't parse while color: {e} - is it formatted like a CSS color?")))?;;
+	let white = parse_color_to_i32(&flags.white_color.unwrap_or("FFFFFF".into())).map_err(|e| {
+		BadTermSizeStdin(format!(
+			"Couldn't parse while color: {e} - is it formatted like a CSS color?"
+		))
+	})?;
 
 	let (watch_to_render_tx, render_rx) = flume::unbounded();
 	let tui_tx = watch_to_render_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,7 +304,7 @@ fn on_notify_ev(
 fn parse_color_to_i32(cs: &str) -> Result<i32, csscolorparser::ParseColorError> {
 	let color = csscolorparser::parse(cs)?;
 	let [r, g, b, _] = color.to_rgba8();
-	let u: u32 = r as u32 * 256 * 256 + g as u32 * 256 + b as u32;
+	let u: u32 = u32::from(r) * 256 * 256 + u32::from(g) * 256 + u32::from(b);
 	let bytes = u.to_le_bytes();
-	return Ok(i32::from_le_bytes(bytes));
+	Ok(i32::from_le_bytes(bytes))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		/// The number of pages to prerender surrounding the currently-shown page; 0 means no
 		/// limit. By default, there is no limit.
 		optional -p,--prerender prerender: usize
-		/// Custom white color
+		/// Custom white color, specified in css format (e.g. "FFFFFF" or "rgb(255, 255, 255)")
 		optional -w,--white-color white: String
-		/// Custom black color
+		/// Custom black color, specified in css format (e.g "000000" or "rgb(0, 0, 0)")
 		optional -b,--black-color black: String
 		/// PDF file to read
 		required file: PathBuf

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,9 +60,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	};
 
 	let path = flags.file.canonicalize()?;
-	let black = parse_color_to_i32(&flags.black_color.unwrap_or("000000".into()))?;
+	let black = parse_color_to_i32(&flags.black_color.unwrap_or("000000".into()))
+		.map_err(|e| BadTermSizeStdin(format!("Couldn't parse black color: {e} - is it formatted like a CSS color?")))?;
 
-	let white = parse_color_to_i32(&flags.white_color.unwrap_or("FFFFFF".into()))?;
+	let white = parse_color_to_i32(&flags.white_color.unwrap_or("FFFFFF".into()))
+		.map_err(|e| BadTermSizeStdin(format!("Couldn't parse while color: {e} - is it formatted like a CSS color?")))?;;
 
 	let (watch_to_render_tx, render_rx) = flume::unbounded();
 	let tui_tx = watch_to_render_tx.clone();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -76,7 +76,9 @@ pub fn start_rendering(
 	sender: Sender<Result<RenderInfo, RenderError>>,
 	receiver: Receiver<RenderNotif>,
 	size: WindowSize,
-	prerender: PrerenderLimit
+	prerender: PrerenderLimit,
+	black: i32,
+	white: i32
 ) -> Result<(), SendError<Result<RenderInfo, RenderError>>> {
 	// We want this outside of 'reload so that if the doc reloads, the search term that somebody
 	// set will still get highlighted in the reloaded doc
@@ -282,6 +284,8 @@ pub fn start_rendering(
 					search_term.as_deref(),
 					rendered,
 					invert,
+					black,
+					white,
 					(area_w, area_h)
 				) {
 					// If that fn returned Some, that means it needed to be re-rendered for some
@@ -421,6 +425,8 @@ fn render_single_page_to_ctx(
 	search_term: Option<&str>,
 	prev_render: &PrevRender,
 	invert: bool,
+	black: i32,
+	white: i32,
 	(area_w, area_h): (f32, f32)
 ) -> Result<RenderedContext, mupdf::error::Error> {
 	let result_rects = match prev_render.num_search_found {
@@ -461,7 +467,9 @@ fn render_single_page_to_ctx(
 
 	let mut pixmap = page.to_pixmap(&matrix, &colorspace, false, false)?;
 	if invert {
-		pixmap.invert()?;
+		pixmap.tint(white, black)?;
+	} else {
+		pixmap.tint(black, white)?;
 	}
 
 	let (x_res, y_res) = pixmap.resolution();


### PR DESCRIPTION
This PR addresses #62. 
We can pass different colors for black and white as arguments:
`tdf file.pdf  -b FFFFFF -w 2E3440`
the arguments default to black and white. 
The idea is to use `mupdf_tint_pixmap(..)` to change the colors. This nicely maps all other colors. 
When inverting, black and white are swapped. This means that if I select two colors from my preferred color-scheme, 
they are still present, when inverting. (For black and white this appears to be identical to the old invert.)
There are a few drawbacks:
- A lot of functions get the colors added to their signature. This is a bit ugly and leads to a lot of changes for a relatively small feature. 
- There is a new dependencies on the `csscolorparser` crate. That is not at all necessary to parse a simple hex string, but maybe it is a bit nicer to support a lot of standard representations of colors. 
- Transparency is not supported. 

Note: The `mupdf_tint_pixmap(..)` function takes the color as an `i32`. It seems to work correctly if I build the normal `u32` of the color and then create a `i32` from its bytes. Maybe there is a simpler way to do this. I do not fully understand the color format it is using. 

  

