### PR TITLE
New kitty image backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,8 @@ jobs:
       run: rustup component add clippy rustfmt
     - name: Clippy
       run: cargo clippy -- -D warnings
+    - name: Tests
+      run: cargo test
     - name: Check fmt
       run: cargo fmt -- --check
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-- Update ratatui(-image) dependencies
+- Update to new `kittage` backend for kitty-protocol-supporting terminals (fixes many issues and improves performance significantly, see [the PR](https://github.com/itsjunetime/tdf/pull/74))
 - Use new mupdf search API for slightly better performance
+- Update ratatui(-image) dependencies
+- Allow specification of default white and black colors for rendered pdfs
 - Pause rendering every once in a while while there's a search term to enable searching across the entire document more quickly
 - Fix an issue with missing search highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kittage"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "crossterm",
+ "futures-core",
+ "image",
+ "memchr",
+ "memmap2",
+ "psx-shm",
+ "rustix 1.0.8",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1713,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -2289,6 +2314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "psx-shm"
+version = "0.1.1"
+source = "git+https://github.com/itsjunetime/psx-shm.git#3fcbae91217cd50ea0e4c838276ef7500cccf024"
+dependencies = [
+ "memmap2",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -2907,6 +2941,8 @@ dependencies = [
  "futures-util",
  "image",
  "itertools 0.14.0",
+ "kittage",
+ "memmap2",
  "mimalloc",
  "mupdf",
  "nix 0.30.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
@@ -645,12 +645,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1508,15 +1508,6 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +400,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -969,6 +996,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb03342077df16d5b1400d7bed00156882846d7a479ff61a6f10594bcc3423d8"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1369,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1879,6 +1943,15 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2937,11 +3010,13 @@ dependencies = [
  "criterion",
  "crossterm",
  "csscolorparser 0.7.2",
+ "flexi_logger",
  "flume",
  "futures-util",
  "image",
  "itertools 0.14.0",
  "kittage",
+ "log",
  "memmap2",
  "mimalloc",
  "mupdf",
@@ -3627,7 +3702,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3637,11 +3712,24 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3656,10 +3744,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3682,13 +3792,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
 [[package]]
 name = "kittage"
 version = "0.1.0"
+source = "git+https://github.com/itsjunetime/kittage.git#d872c44f7fc1d3a9f5f1efdc710c300f7ea31d9f"
 dependencies = [
  "base64 0.22.1",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb03342077df16d5b1400d7bed00156882846d7a479ff61a6f10594bcc3423d8"
+checksum = "ab9765cc4ba26211f932a7a37649ec88752f7abcbd8822617572562ce31234df"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9765cc4ba26211f932a7a37649ec88752f7abcbd8822617572562ce31234df"
+checksum = "759bfa52db036a2db54f0b5f0ff164efa249b3014720459c5ea4198380c529bc"
 dependencies = [
  "chrono",
  "log",
@@ -1591,6 +1591,7 @@ dependencies = [
  "crossterm",
  "futures-core",
  "image",
+ "log",
  "memchr",
  "memmap2",
  "psx-shm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,7 +3015,6 @@ dependencies = [
  "flume",
  "futures-util",
  "image",
- "itertools 0.14.0",
  "kittage",
  "log",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ mimalloc = "0.1.43"
 nix = { version = "0.30.0", features = ["signal"] }
 mupdf = { version = "0.5.0", default-features = false, features = ["svg", "system-fonts", "img"] }
 rayon = { version = "*", default-features = false }
+kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate"] }
+memmap2 = "*"
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ mimalloc = "0.1.43"
 nix = { version = "0.30.0", features = ["signal"] }
 mupdf = { version = "0.5.0", default-features = false, features = ["svg", "system-fonts", "img"] }
 rayon = { version = "*", default-features = false }
-# kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate"] }
-kittage = { git = "https://github.com/itsjunetime/kittage.git", features = ["crossterm-tokio", "image-crate"] }
+# kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate", "log"] }
+kittage = { git = "https://github.com/itsjunetime/kittage.git", features = ["crossterm-tokio", "image-crate", "log"] }
 memmap2 = "*"
 
 # logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ memmap2 = "*"
 
 # logging
 log = "0.4.27"
-flexi_logger = "0.30.2"
+flexi_logger = "0.31"
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ mimalloc = "0.1.43"
 nix = { version = "0.30.0", features = ["signal"] }
 mupdf = { version = "0.5.0", default-features = false, features = ["svg", "system-fonts", "img"] }
 rayon = { version = "*", default-features = false }
-kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate"] }
+# kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate"] }
+kittage = { git = "https://github.com/itsjunetime/kittage.git", features = ["crossterm-tokio", "image-crate"] }
 memmap2 = "*"
 
 # logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ epub = ["mupdf/epub"]
 cbz = ["mupdf/cbz"]
 
 [dev-dependencies]
-criterion = { version = "0.6.0", features = ["async_tokio"] }
+criterion = { version = "0.7.0", features = ["async_tokio"] }
 cpuprofiler = "0.0.4"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ratatui = { git = "https://github.com/itsjunetime/ratatui.git" }
 ratatui-image = { git = "https://github.com/itsjunetime/ratatui-image.git", branch = "vb64_on_personal", default-features = false }
 # ratatui-image = { path = "./ratatui-image", default-features = false }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
+# crossterm = { path = "../crossterm", features = ["event-stream"] }
 image = { version = "0.25.1", features = ["pnm", "rayon", "png"], default-features = false }
 notify = { version = "8.0.0", features = ["crossbeam-channel"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
@@ -42,6 +43,10 @@ mupdf = { version = "0.5.0", default-features = false, features = ["svg", "syste
 rayon = { version = "*", default-features = false }
 kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate"] }
 memmap2 = "*"
+
+# logging
+log = "0.4.27"
+flexi_logger = "0.30.2"
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ image = { version = "0.25.1", features = ["pnm", "rayon", "png"], default-featur
 notify = { version = "8.0.0", features = ["crossbeam-channel"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
 futures-util = { version = "0.3.30", default-features = false }
-itertools = "*"
 flume = { version = "0.11.0", default-features = false, features = ["async"] }
 xflags = "0.4.0-pre.2"
 mimalloc = "0.1.43"

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -87,12 +87,15 @@ pub fn start_rendering_loop(
 	};
 	to_render_tx.send(RenderNotif::Area(main_area)).unwrap();
 
+	let cell_height_px = size.height / size.rows;
+	let cell_width_px = size.width / size.columns;
 	std::thread::spawn(move || {
 		start_rendering(
 			&str_path,
 			to_main_tx,
 			from_main_rx,
-			size,
+			cell_height_px,
+			cell_width_px,
 			tdf::PrerenderLimit::All,
 			black,
 			white

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -122,7 +122,9 @@ pub fn start_converting_loop(
 		to_main_tx,
 		from_main_rx,
 		picker,
-		prerender
+		prerender,
+		// just assume shms work for now, who cares
+		true
 	));
 
 	let from_converter_rx = from_converter_rx.into_stream();

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -17,7 +17,7 @@ use crate::renderer::{PageInfo, RenderError, fill_default};
 
 #[derive(Debug)]
 pub enum MaybeTransferred {
-	NotYet(kittage::image::Image<'static>, memmap2::MmapMut),
+	NotYet(kittage::image::Image<'static>),
 	Transferred(kittage::ImageId)
 }
 
@@ -124,13 +124,13 @@ pub async fn run_conversion_loop(
 
 				match kittage::image::Image::shm_from(
 					dyn_img,
-					format!("__tdf_kittage_{pid}_page_{page_num}").into()
+					&format!("__tdf_kittage_{pid}_page_{page_num}")
 				) {
-					Ok((mut img, map)) => {
+					Ok(mut img) => {
 						img.num_or_id =
 							NumberOrId::Id(NonZeroU32::new(page_num as u32 + 1).unwrap());
 						ConvertedImage::Kitty {
-							img: MaybeTransferred::NotYet(img, map),
+							img: MaybeTransferred::NotYet(img),
 							area
 						}
 					}

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -76,11 +76,11 @@ pub async fn run_conversion_loop(
 
 		// then we go through all the indices available to us and find the first one that has an
 		// image available to steal
-		let Some((page_info, new_iter)) = (idx_start..page)
+		let Some((page_info, new_iter, page_num)) = (idx_start..page)
 			.interleave(page..idx_end)
 			.enumerate()
 			// .skip(*iteration)
-			.find_map(|(i_idx, p_idx)| images[p_idx].take().map(|p| (p, i_idx)))
+			.find_map(|(i_idx, p_idx)| images[p_idx].take().map(|p| (p, i_idx, p_idx)))
 		else {
 			return Ok(None);
 		};
@@ -124,10 +124,11 @@ pub async fn run_conversion_loop(
 
 				match kittage::image::Image::shm_from(
 					dyn_img,
-					format!("__tdf_kittage_{pid}_page_{page}").into()
+					format!("__tdf_kittage_{pid}_page_{page_num}").into()
 				) {
 					Ok((mut img, map)) => {
-						img.num_or_id = NumberOrId::Id(NonZeroU32::new(page as u32 + 1).unwrap());
+						img.num_or_id =
+							NumberOrId::Id(NonZeroU32::new(page_num as u32 + 1).unwrap());
 						ConvertedImage::Kitty {
 							img: MaybeTransferred::NotYet(img, map),
 							area

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,4 +1,7 @@
-use std::num::{NonZeroU32, NonZeroUsize};
+use std::{
+	num::{NonZeroU32, NonZeroUsize},
+	time::{SystemTime, UNIX_EPOCH}
+};
 
 use flume::{Receiver, SendError, Sender, TryRecvError};
 use futures_util::stream::StreamExt;
@@ -127,10 +130,15 @@ pub async fn run_conversion_loop(
 					picker.font_size()
 				);
 
+				let rn = SystemTime::now()
+					.duration_since(UNIX_EPOCH)
+					.unwrap_or_default()
+					.as_nanos();
+
 				let mut img = if shms_work {
 					kittage::image::Image::shm_from(
 						dyn_img,
-						&format!("__tdf_kittage_{pid}_page_{page_num}")
+						&format!("__tdf_kittage_{pid}_page_{rn}_{page_num}")
 					)
 					.map_err(|e| RenderError::Converting(format!("Couldn't write to shm: {e}")))?
 				} else {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -20,6 +20,7 @@ use crate::{
 	skip::InterleavedAroundWithMax
 };
 
+#[derive(Debug)]
 pub enum MaybeTransferred {
 	NotYet(kittage::image::Image<'static>),
 	Transferred(kittage::ImageId)

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -172,8 +172,6 @@ pub async fn display_kitty_images<'es>(
 
 				match res {
 					Ok(img_id) => {
-						// TODO: Re-add this or at least make sure this sort of thing does happen
-						// fake_image.unlink_if_shm();
 						*img = MaybeTransferred::Transferred(img_id);
 						Ok(())
 					}

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -11,7 +11,7 @@ use kittage::{
 	AsyncInputReader, ImageDimensions, ImageId, NumberOrId, PixelFormat,
 	action::Action,
 	delete::{ClearOrDelete, DeleteConfig, WhichToDelete},
-	display::{DisplayConfig, DisplayLocation},
+	display::{CursorMovementPolicy, DisplayConfig, DisplayLocation},
 	error::TransmitError,
 	image::Image,
 	medium::Medium
@@ -137,10 +137,14 @@ pub async fn display_kitty_images<'es>(
 	{
 		let config = DisplayConfig {
 			location: display_loc,
+			cursor_movement: CursorMovementPolicy::DontMove,
 			..DisplayConfig::default()
 		};
 
 		execute!(std::io::stdout(), MoveTo(pos.x, pos.y)).unwrap();
+
+		log::debug!("going to display img {img:#?}");
+		log::debug!("displaying with config {config:#?}");
 
 		let this_err = match img {
 			MaybeTransferred::NotYet(image) => {
@@ -190,6 +194,8 @@ pub async fn display_kitty_images<'es>(
 			.map(|_| ())
 			.map_err(|e| (page_num, e))
 		};
+
+		log::debug!("this_err is {this_err:#?}");
 
 		if let Err((id, e)) = this_err {
 			let e = err.get_or_insert_with(|| (vec![], e));

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,7 +1,18 @@
-use std::io::Write;
+use std::{io::Write, num::NonZeroU32};
 
-use crossterm::event::EventStream;
-use kittage::{AsyncInputReader, ImageId, action::Action, error::TransmitError};
+use crossterm::{cursor::MoveTo, event::EventStream, execute};
+use kittage::{
+	AsyncInputReader, ImageDimensions, ImageId, PixelFormat,
+	action::Action,
+	delete::{ClearOrDelete, DeleteConfig, WhichToDelete},
+	display::DisplayConfig,
+	error::TransmitError,
+	image::Image,
+	medium::Medium
+};
+use ratatui::prelude::Rect;
+
+use crate::converter::MaybeTransferred;
 
 #[derive(Debug)]
 pub struct DbgWriter<W: Write> {
@@ -45,4 +56,116 @@ pub async fn run_action<'image, 'data, 'es>(
 		.execute_async(writer, ev_stream)
 		.await
 		.map(|(_, i)| i)
+}
+
+pub async fn display_kitty_images(
+	images: Vec<(usize, &mut MaybeTransferred, Rect)>,
+	ev_stream: &mut EventStream
+) -> Result<(), (Vec<usize>, String)> {
+	run_action(
+		Action::Delete(DeleteConfig {
+			effect: ClearOrDelete::Clear,
+			which: WhichToDelete::All
+		}),
+		ev_stream
+	)
+	.await
+	.map_err(|e| (vec![], format!("Couldn't clear previous images: {e}")))?;
+
+	let mut err = None;
+	for (page_num, img, area) in images {
+		let config = DisplayConfig::default();
+
+		execute!(std::io::stdout(), MoveTo(area.x, area.y)).unwrap();
+
+		log::debug!("looking at (area {area:?}) img {img:#?}");
+
+		let this_err = match img {
+			MaybeTransferred::NotYet(image, _map) => {
+				let mut fake_image = Image {
+					num_or_id: image.num_or_id,
+					format: PixelFormat::Rgb24(
+						ImageDimensions {
+							width: 0,
+							height: 0
+						},
+						None
+					),
+					medium: Medium::Direct {
+						chunk_size: None,
+						data: (&[]).into()
+					}
+				};
+				std::mem::swap(image, &mut fake_image);
+
+				log::debug!("Actually trying to display an image now: {fake_image:?}...");
+
+				let res = run_action(
+					Action::TransmitAndDisplay {
+						image: fake_image,
+						config,
+						placement_id: None
+					},
+					ev_stream
+				)
+				.await;
+
+				log::debug!("And it should've gone through: {res:?}!...");
+
+				match res {
+					Ok(img_id) => {
+						// We need the `_map` to be dropped here, but can't explicitly carry it
+						// over to here. So we're just relying on the overwrite of `img` to
+						// drop `_map` (and thus unmap the memory) for us
+						*img = MaybeTransferred::Transferred(img_id);
+						Ok(())
+					}
+					Err(e) => Err(match e {
+						TransmitError::Writing(action, e) => {
+							let num = if let Action::TransmitAndDisplay {
+								image: failed_img, ..
+							} = *action
+							{
+								*image = failed_img;
+								None
+							} else {
+								Some(page_num)
+							};
+
+							(num, e.to_string())
+						}
+						_ => (Some(page_num), e.to_string())
+					})
+				}
+			}
+			MaybeTransferred::Transferred(image_id) => {
+				let e = run_action(
+					Action::Display {
+						image_id: *image_id,
+						placement_id: NonZeroU32::new(1).unwrap(),
+						config
+					},
+					ev_stream
+				)
+				.await
+				.map(|_| ())
+				.map_err(|e| (None, e.to_string()));
+
+				log::debug!("Just tried to display: {e:?}");
+				e
+			}
+		};
+
+		if let Err((id, e)) = this_err {
+			let e = err.get_or_insert_with(|| (vec![], e));
+			if let Some(id) = id {
+				e.0.push(id);
+			}
+		}
+	}
+
+	match err {
+		Some(e) => Err(e),
+		None => Ok(())
+	}
 }

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, num::NonZeroU32};
+use std::io::Write;
 
 use crossterm::{cursor::MoveTo, event::EventStream, execute};
 use kittage::{
@@ -62,6 +62,10 @@ pub async fn display_kitty_images(
 	images: Vec<(usize, &mut MaybeTransferred, Rect)>,
 	ev_stream: &mut EventStream
 ) -> Result<(), (Vec<usize>, String)> {
+	if images.is_empty() {
+		return Ok(());
+	}
+
 	run_action(
 		Action::Delete(DeleteConfig {
 			effect: ClearOrDelete::Clear,
@@ -142,7 +146,7 @@ pub async fn display_kitty_images(
 				let e = run_action(
 					Action::Display {
 						image_id: *image_id,
-						placement_id: NonZeroU32::new(1).unwrap(),
+						placement_id: *image_id,
 						config
 					},
 					ev_stream

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -35,7 +35,6 @@ impl<W: Write> Write for DbgWriter<W> {
 	fn flush(&mut self) -> std::io::Result<()> {
 		#[cfg(debug_assertions)]
 		{
-			log::debug!("wrote {:?}", self.buf);
 			self.buf.clear();
 		}
 		self.w.flush()
@@ -82,8 +81,6 @@ pub async fn display_kitty_images(
 
 		execute!(std::io::stdout(), MoveTo(area.x, area.y)).unwrap();
 
-		log::debug!("looking at (area {area:?}) img {img:#?}");
-
 		let this_err = match img {
 			MaybeTransferred::NotYet(image) => {
 				let mut fake_image = Image {
@@ -102,8 +99,6 @@ pub async fn display_kitty_images(
 				};
 				std::mem::swap(image, &mut fake_image);
 
-				log::debug!("Actually trying to display an image now: {fake_image:?}...");
-
 				let res = run_action(
 					Action::TransmitAndDisplay {
 						image: fake_image,
@@ -114,8 +109,6 @@ pub async fn display_kitty_images(
 				)
 				.await;
 
-				log::debug!("And it should've gone through: {res:?}!...");
-
 				match res {
 					Ok(img_id) => {
 						*img = MaybeTransferred::Transferred(img_id);
@@ -125,7 +118,7 @@ pub async fn display_kitty_images(
 				}
 			}
 			MaybeTransferred::Transferred(image_id) => {
-				let e = run_action(
+				run_action(
 					Action::Display {
 						image_id: *image_id,
 						placement_id: *image_id,
@@ -135,10 +128,7 @@ pub async fn display_kitty_images(
 				)
 				.await
 				.map(|_| ())
-				.map_err(|e| (None, e.to_string()));
-
-				log::debug!("Just tried to display: {e:?}");
-				e
+				.map_err(|e| (None, e.to_string()))
 			}
 		};
 

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,0 +1,48 @@
+use std::io::Write;
+
+use crossterm::event::EventStream;
+use kittage::{AsyncInputReader, ImageId, action::Action, error::TransmitError};
+
+#[derive(Debug)]
+pub struct DbgWriter<W: Write> {
+	w: W,
+	#[cfg(debug_assertions)]
+	buf: String
+}
+
+impl<W: Write> Write for DbgWriter<W> {
+	fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+		#[cfg(debug_assertions)]
+		{
+			if let Ok(s) = std::str::from_utf8(buf) {
+				self.buf.push_str(s);
+			}
+		}
+		self.w.write(buf)
+	}
+
+	fn flush(&mut self) -> std::io::Result<()> {
+		#[cfg(debug_assertions)]
+		{
+			log::debug!("wrote {:?}", self.buf);
+			self.buf.clear();
+		}
+		self.w.flush()
+	}
+}
+
+pub async fn run_action<'image, 'data, 'es>(
+	action: Action<'image, 'data>,
+	ev_stream: &'es mut EventStream
+) -> Result<ImageId, TransmitError<'image, 'data, <&'es mut EventStream as AsyncInputReader>::Error>>
+{
+	let writer = DbgWriter {
+		w: std::io::stdout().lock(),
+		#[cfg(debug_assertions)]
+		buf: String::new()
+	};
+	action
+		.execute_async(writer, ev_stream)
+		.await
+		.map(|(_, i)| i)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[derive(PartialEq)]
 pub enum PrerenderLimit {
 	All,
 	Limited(NonZeroUsize)
@@ -13,3 +14,46 @@ pub mod kitty;
 pub mod renderer;
 pub mod skip;
 pub mod tui;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum FitOrFill {
+	Fit,
+	Fill
+}
+
+pub struct ScaledResult {
+	width: f32,
+	height: f32,
+	scale_factor: f32
+}
+
+pub fn scale_img_for_area(
+	(img_width, img_height): (f32, f32),
+	(area_width, area_height): (f32, f32),
+	fit_or_fill: FitOrFill
+) -> ScaledResult {
+	// and get its aspect ratio
+	let img_aspect_ratio = img_width / img_height;
+
+	// Then we get the full pixel dimensions of the area provided to us, and the aspect ratio
+	// of that area
+	let area_aspect_ratio = area_width / area_height;
+
+	// and get the ratio that this page would have to be scaled by to fit perfectly within the
+	// area provided to us.
+	// we do this first by comparing the aspec ratio of the page with the aspect ratio of the
+	// area to fit it within. If the aspect ratio of the page is larger, then we need to scale
+	// the width of the page to fill perfectly within the height of the area. Otherwise, we
+	// scale the height to fit perfectly. The dimension that _is not_ scaled to fit perfectly
+	// is scaled by the same factor as the dimension that _is_ scaled perfectly.
+	let scale_factor = match (img_aspect_ratio > area_aspect_ratio, fit_or_fill) {
+		(true, FitOrFill::Fit) | (false, FitOrFill::Fill) => area_width / img_width,
+		(false, FitOrFill::Fit) | (true, FitOrFill::Fill) => area_height / img_height
+	};
+
+	ScaledResult {
+		width: img_width * scale_factor,
+		height: img_height * scale_factor,
+		scale_factor
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub enum PrerenderLimit {
 }
 
 pub mod converter;
+pub mod kitty;
 pub mod renderer;
 pub mod skip;
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,9 @@ async fn enter_redraw_loop(
 						InputAction::Search(term) => to_renderer.send(RenderNotif::Search(term))?,
 						InputAction::Invert => to_renderer.send(RenderNotif::Invert)?,
 						InputAction::Fullscreen => fullscreen = !fullscreen,
+						InputAction::SwitchRenderZoom(f_or_f) => {
+							to_renderer.send(RenderNotif::SwitchFitOrFill(f_or_f)).unwrap();
+						}
 					}
 				}
 			},
@@ -354,7 +357,12 @@ async fn enter_redraw_loop(
 			}
 			Some(img_res) = from_converter.next() => {
 				match img_res {
-					Ok(ConvertedPage { page, num, num_results }) => tui.page_ready(page, num, num_results),
+					Ok(ConvertedPage { page, num, num_results }) => {
+						tui.page_ready(page, num, num_results);
+						if num == tui.page {
+							needs_redraw = true;
+						}
+					},
 					Err(e) => tui.show_error(e),
 				}
 			},

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,12 @@ async fn main() -> Result<(), WrappedErr> {
 		|| "Unknown file".into(),
 		|n| n.to_string_lossy().to_string()
 	);
-	let tui = Tui::new(file_name, flags.max_wide, flags.r_to_l.unwrap_or_default());
+	let tui = Tui::new(
+		file_name,
+		flags.max_wide,
+		flags.r_to_l.unwrap_or_default(),
+		is_kitty
+	);
 
 	let backend = CrosstermBackend::new(std::io::stdout());
 	let mut term = Terminal::new(backend).map_err(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,12 +427,10 @@ async fn enter_redraw_loop(
 
 				if let Err((to_replace, err_desc, enum_err)) = maybe_err {
 					match enum_err {
-						// This is the error that kitty provides us when it deletes an image due to
-						// memory constraints, so if we get it, we just fix it by re-rendering and
-						// don't display it to the user
-						TransmitError::Terminal(TerminalError::NoEntity(e))
-							if e.contains("refers to non-existent image") =>
-							(),
+						// This is the error that kitty & ghostty provide us when they delete an
+						// image due to memory constraints, so if we get it, we just fix it by
+						// re-rendering so it don't display it to the user
+						TransmitError::Terminal(TerminalError::NoEntity(_)) => (),
 						_ => tui.set_msg(MessageSetting::Some(BottomMessage::Error(format!(
 							"{err_desc}: {enum_err}"
 						))))

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use core::error::Error;
 use std::{
 	borrow::Cow,
 	ffi::OsString,
-	io::{stdout, BufReader, Read, Stdout},
+	io::{BufReader, Read, Stdout, stdout},
 	num::{NonZeroU32, NonZeroUsize},
 	path::PathBuf
 };
@@ -15,8 +15,8 @@ use crossterm::{
 		enable_raw_mode, window_size
 	}
 };
-use flume::{Sender, r#async::RecvStream};
 use flexi_logger::FileSpec;
+use flume::{Sender, r#async::RecvStream};
 use futures_util::{FutureExt, stream::StreamExt};
 use kittage::{
 	action::Action,
@@ -25,7 +25,10 @@ use kittage::{
 };
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 use ratatui::{Terminal, backend::CrosstermBackend};
-use ratatui_image::{picker::{Picker, ProtocolType}, FontSize};
+use ratatui_image::{
+	FontSize,
+	picker::{Picker, ProtocolType}
+};
 use tdf::{
 	PrerenderLimit,
 	converter::{ConvertedPage, ConverterMsg, run_conversion_loop},
@@ -101,16 +104,15 @@ async fn main() -> Result<(), WrappedErr> {
 	let mut maybe_logger = None;
 
 	if std::env::var("RUST_LOG").is_ok() {
-		maybe_logger =
-			Some(
-				flexi_logger::Logger::try_with_env()
-					.map_err(|e| WrappedErr(format!("Couldn't create initial logger: {e}").into()))?
-					.log_to_file(FileSpec::try_from("./debug.log").map_err(|e| {
-						WrappedErr(format!("Couldn't create FileSpec for logger: {e}").into())
-					})?)
-					.start()
-					.map_err(|e| WrappedErr(format!("Can't start logger: {e}").into()))?
-			);
+		maybe_logger = Some(
+			flexi_logger::Logger::try_with_env()
+				.map_err(|e| WrappedErr(format!("Couldn't create initial logger: {e}").into()))?
+				.log_to_file(FileSpec::try_from("./debug.log").map_err(|e| {
+					WrappedErr(format!("Couldn't create FileSpec for logger: {e}").into())
+				})?)
+				.start()
+				.map_err(|e| WrappedErr(format!("Can't start logger: {e}").into()))?
+		);
 	}
 
 	let (watch_to_render_tx, render_rx) = flume::unbounded();
@@ -250,7 +252,9 @@ async fn main() -> Result<(), WrappedErr> {
 			&mut ev_stream
 		)
 		.await
-		.map_err(|e| WrappedErr(format!("Couldn't delete all previous images from memory: {e}").into()))?;
+		.map_err(|e| {
+			WrappedErr(format!("Couldn't delete all previous images from memory: {e}").into())
+		})?;
 	}
 
 	let fullscreen = flags.fullscreen.unwrap_or_default();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,5 @@
 use std::{thread::sleep, time::Duration};
 
-use crossterm::terminal::WindowSize;
 use flume::{Receiver, SendError, Sender, TryRecvError};
 use itertools::Itertools;
 use mupdf::{
@@ -78,7 +77,8 @@ pub fn start_rendering(
 	path: &str,
 	sender: Sender<Result<RenderInfo, RenderError>>,
 	receiver: Receiver<RenderNotif>,
-	size: WindowSize,
+	col_h: u16,
+	col_w: u16,
 	prerender: PrerenderLimit,
 	black: i32,
 	white: i32
@@ -88,9 +88,7 @@ pub fn start_rendering(
 	let mut search_term = None;
 
 	// And although the font size could theoretically change, we aren't accounting for that right
-	// now, so we just keep this out of the loop.
-	let col_w = size.width / size.columns;
-	let col_h = size.height / size.rows;
+	// now, so we just use the values passed in.
 
 	let mut stored_doc = None;
 	let mut invert = false;

--- a/src/skip.rs
+++ b/src/skip.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use ratatui::widgets::Widget;
 
 pub struct Skip {
@@ -17,5 +19,109 @@ impl Widget for Skip {
 				buf[(x, y)].skip = self.skip;
 			}
 		}
+	}
+}
+
+enum PlusOrMinus {
+	Plus,
+	Minus
+}
+
+pub struct InterleavedAroundWithMax {
+	// starts at this number
+	around: usize,
+	inclusive_min: usize,
+	// this iterator can only produce values in [0..max)
+	exclusive_max: NonZeroUsize,
+	// the next time we call `next()`, this value should be combined with `around` according to
+	// `next_op`, then, after next_op is inverted, incremented if next_op was negative before being
+	// inverted.
+	next_change: usize,
+	// How `next_change` should be applied to `around` next time `next()` is called
+	next_op: PlusOrMinus
+}
+
+impl InterleavedAroundWithMax {
+	/// the following must hold or else this is liable to panic or produce nonsense values:
+	/// - inclusive_min < exclusive_max
+	/// - inclusive_min <= around <= exclusive_max
+	pub fn new(around: usize, inclusive_min: usize, exclusive_max: NonZeroUsize) -> Self {
+		Self {
+			around,
+			inclusive_min,
+			exclusive_max,
+			next_change: 0,
+			next_op: PlusOrMinus::Minus
+		}
+	}
+}
+
+impl Iterator for InterleavedAroundWithMax {
+	type Item = usize;
+	fn next(&mut self) -> Option<Self::Item> {
+		let actual_change = self.next_change % (self.exclusive_max.get() - self.inclusive_min);
+
+		let to_return = match self.next_op {
+			// If we're supposed to add them and we need it to wrap, then try to add them together
+			// 'cause we need special behavior if it overflows usize's limits
+			PlusOrMinus::Plus => match self.around.checked_add(actual_change) {
+				// If we added it and it's within the range, we're chillin
+				Some(next_val) if next_val < self.exclusive_max.get() => next_val,
+				// If we added it and it's not within the range, do next_val % (self.max + 1), e.g.
+				// if max is 20, we were at 15, and we added 7, we should get 1 (because +5 would
+				// hit the max, then 0, then 1). So adding 1 before the modulo makes it hit the
+				// right numbers. And we can be sure the + here doesn't overflow 'cause we already
+				// checked the `usize::MAX` up above
+				Some(next_val) => (next_val % self.exclusive_max.get()) + self.inclusive_min,
+				// If we added them and it would've overflowed usize::MAX, then we see how much
+				// of the change would be remaining after reaching `max`
+				None =>
+					(actual_change - (self.exclusive_max.get() - actual_change))
+						+ self.inclusive_min,
+			},
+			PlusOrMinus::Minus => match self.around.checked_sub(actual_change) {
+				// If we can just minus it, cool cool. All is good.
+				Some(next_val) if next_val >= self.inclusive_min => next_val,
+				// If we can minus it but it goes below our min, then see how much below it went
+				// and just manually wrap it around
+				Some(next_val) => self.exclusive_max.get() - (self.inclusive_min - next_val),
+				// If we can't...
+				None => {
+					// then we see how much of the change would be remaining after hitting the
+					// minimum
+					let remaining = actual_change - (self.around - self.inclusive_min);
+
+					// and then we take that away from the top!
+					self.exclusive_max.get() - remaining
+				}
+			}
+		};
+
+		self.next_op = match self.next_op {
+			PlusOrMinus::Plus => PlusOrMinus::Minus,
+			PlusOrMinus::Minus => {
+				self.next_change = (self.next_change + 1) % self.exclusive_max.get();
+				PlusOrMinus::Plus
+			}
+		};
+
+		Some(to_return)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn iter_works() {
+		let got = InterleavedAroundWithMax::new(5, 2, NonZeroUsize::new(21).unwrap())
+			.take(30)
+			.collect::<Vec<_>>();
+
+		assert_eq!(got, vec![
+			5, 6, 4, 7, 3, 8, 2, 9, 20, 10, 19, 11, 18, 12, 17, 13, 16, 14, 15, 15, 14, 16, 13, 17,
+			12, 18, 11, 19, 10, 20
+		]);
 	}
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,6 +24,7 @@ use ratatui_image::Image;
 
 use crate::{
 	converter::{ConvertedImage, MaybeTransferred},
+	kitty::KittyDisplay,
 	renderer::{RenderError, fill_default},
 	skip::Skip
 };
@@ -133,10 +134,10 @@ impl Tui {
 		&'s mut self,
 		frame: &mut Frame<'_>,
 		full_layout: &RenderLayout
-	) -> Vec<(usize, &'s mut MaybeTransferred, Rect)> {
+	) -> KittyDisplay<'s> {
 		if self.showing_help_msg {
 			self.render_help_msg(frame);
-			return vec![];
+			return KittyDisplay::ClearImages;
 		}
 
 		if let Some((top_area, bottom_area)) = full_layout.top_and_bottom {
@@ -243,7 +244,7 @@ impl Tui {
 			// be written and set to skip it so that ratatui doesn't spend a lot of time diffing it
 			// each re-render
 			frame.render_widget(Skip::new(true), img_area);
-			vec![]
+			KittyDisplay::NoChange
 		} else {
 			// here we calculate how many pages can fit in the available area.
 			let mut test_area_w = img_area.width;
@@ -279,7 +280,7 @@ impl Tui {
 			if page_widths.is_empty() {
 				// If none are ready to render, just show the loading thing
 				Self::render_loading_in(frame, img_area);
-				vec![]
+				KittyDisplay::ClearImages
 			} else {
 				execute!(stdout(), BeginSynchronizedUpdate).unwrap();
 
@@ -306,7 +307,7 @@ impl Tui {
 				// then the whole diffing thing messes it up
 				self.last_render.rect = size;
 
-				to_display
+				KittyDisplay::DisplayImages(to_display)
 			}
 		}
 	}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,7 +41,7 @@ pub struct Tui {
 	showing_help_msg: bool
 }
 
-#[derive(Default, Debug)]
+#[derive(Default)]
 struct LastRender {
 	// Used as a way to track if we need to draw the images, to save ratatui from doing a lot of
 	// diffing work

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -133,7 +133,7 @@ impl Tui {
 		&'s mut self,
 		frame: &mut Frame<'_>,
 		full_layout: &RenderLayout
-	) -> Vec<(&'s mut MaybeTransferred, Rect)> {
+	) -> Vec<(usize, &'s mut MaybeTransferred, Rect)> {
 		if self.showing_help_msg {
 			self.render_help_msg(frame);
 			return vec![];
@@ -293,11 +293,12 @@ impl Tui {
 
 				let to_display = page_widths
 					.into_iter()
-					.filter_map(|(width, img)| {
+					.enumerate()
+					.filter_map(|(idx, (width, img))| {
 						let maybe_img =
 							Self::render_single_page(frame, img, Rect { width, ..img_area });
 						img_area.x += width;
-						maybe_img
+						maybe_img.map(|(img, r)| (idx + self.page, img, r))
 					})
 					.collect::<Vec<_>>();
 
@@ -398,6 +399,10 @@ impl Tui {
 			img: Some(img),
 			num_results: Some(num_results)
 		};
+	}
+
+	pub fn page_failed_display(&mut self, page_num: usize) {
+		self.rendered[page_num].img = None;
 	}
 
 	pub fn got_num_results_on_page(&mut self, page_num: usize, num_results: usize) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -428,31 +428,24 @@ impl Tui {
 		frame: &mut Frame<'_>,
 		bottom_msg: &BottomMessage
 	) {
+		// use the extra space here to add some padding to the right side
+		let page_nums_text = format!("{} / {} ", page_num + 1, rendered.len());
+
 		let top_block = Block::new()
+			// use this first title to add a bit of padding to the left side
+			.title_top(" ")
+			.title_top(Span::styled(doc_name, Style::new().fg(Color::Cyan)))
+			.title_top(
+				Span::styled(&page_nums_text, Style::new().fg(Color::Cyan))
+					.into_right_aligned_line()
+			)
 			.padding(Padding {
-				right: 2,
-				left: 2,
+				bottom: 1,
 				..Padding::default()
 			})
 			.borders(Borders::BOTTOM);
 
-		let top_area = top_block.inner(top_area);
-
-		let page_nums_text = format!("{} / {}", page_num + 1, rendered.len());
-
-		let top_layout = Layout::horizontal([
-			Constraint::Fill(1),
-			Constraint::Length(page_nums_text.len() as u16)
-		])
-		.split(top_area);
-
-		let title = Span::styled(doc_name, Style::new().fg(Color::Cyan));
-
-		let page_nums = Span::styled(&page_nums_text, Style::new().fg(Color::Cyan));
-
 		frame.render_widget(top_block, top_area);
-		frame.render_widget(title, top_layout[0]);
-		frame.render_widget(page_nums, top_layout[1]);
 
 		let bottom_block = Block::new()
 			.padding(Padding {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -394,7 +394,8 @@ impl Tui {
 
 		let old = self.page;
 		match change {
-			PageChange::Next => self.set_page((self.page + diff).min(self.rendered.len() - 1)),
+			PageChange::Next =>
+				self.set_page((self.page + diff).min(self.rendered.len().saturating_sub(1))),
 			PageChange::Prev => self.set_page(self.page.saturating_sub(diff))
 		}
 
@@ -653,13 +654,9 @@ impl Tui {
 								self.last_render.rect = Rect::default();
 								Some(InputAction::SwitchRenderZoom(f_or_f))
 							}
-							/*'o' if self.is_kitty => {
-								if let Some(z) = &mut self.zoom {
-									z.level = z.level.saturating_add(1);
-								}
-								self.last_render.rect = Rect::default();
-								Some(InputAction::Redraw)
-							}*/
+							'o' if self.is_kitty => self.update_zoom(|z|
+								// TODO: for now, we don't let people zoom in past fill-screen
+								z.level = z.level.saturating_add(1).min(0)),
 							'O' if self.is_kitty =>
 								self.update_zoom(|z| z.level = z.level.saturating_sub(1)),
 							'L' if self.is_kitty => self.update_zoom(|z| {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -42,6 +42,7 @@ pub struct Tui {
 	rendered: Vec<RenderedInfo>,
 	page_constraints: PageConstraints,
 	showing_help_msg: bool,
+	is_kitty: bool,
 	zoom: Option<Zoom>
 }
 
@@ -107,7 +108,7 @@ pub struct RenderLayout {
 }
 
 impl Tui {
-	pub fn new(name: String, max_wide: Option<NonZeroUsize>, r_to_l: bool) -> Tui {
+	pub fn new(name: String, max_wide: Option<NonZeroUsize>, r_to_l: bool, is_kitty: bool) -> Tui {
 		Self {
 			name,
 			page: 0,
@@ -117,6 +118,7 @@ impl Tui {
 			rendered: vec![],
 			page_constraints: PageConstraints { max_wide, r_to_l },
 			showing_help_msg: false,
+			is_kitty,
 			zoom: None
 		}
 	}
@@ -621,7 +623,7 @@ impl Tui {
 								self.last_render.rect = Rect::default();
 								Some(InputAction::Redraw)
 							}
-							'z' => {
+							'z' if self.is_kitty => {
 								let (zoom, f_or_f) = match self.zoom {
 									None => (Some(Zoom::default()), FitOrFill::Fill),
 									Some(_) => (None, FitOrFill::Fit)
@@ -630,28 +632,28 @@ impl Tui {
 								self.last_render.rect = Rect::default();
 								Some(InputAction::SwitchRenderZoom(f_or_f))
 							}
-							'L' => {
+							'L' if self.is_kitty => {
 								if let Some(z) = &mut self.zoom {
 									z.cell_pan_from_left = z.cell_pan_from_left.saturating_add(1);
 								}
 								self.last_render.rect = Rect::default();
 								Some(InputAction::Redraw)
 							}
-							'H' => {
+							'H' if self.is_kitty => {
 								if let Some(z) = &mut self.zoom {
 									z.cell_pan_from_left = z.cell_pan_from_left.saturating_sub(1);
 								}
 								self.last_render.rect = Rect::default();
 								Some(InputAction::Redraw)
 							}
-							'J' => {
+							'J' if self.is_kitty => {
 								if let Some(z) = &mut self.zoom {
 									z.cell_pan_from_top = z.cell_pan_from_top.saturating_add(1);
 								}
 								self.last_render.rect = Rect::default();
 								Some(InputAction::Redraw)
 							}
-							'K' => {
+							'K' if self.is_kitty => {
 								if let Some(z) = &mut self.zoom {
 									z.cell_pan_from_top = z.cell_pan_from_top.saturating_sub(1);
 								}


### PR DESCRIPTION
Alright, this one is beautiful (once I finish all the final pieces). It replaces, when using a kitty-supporting terminal, the ratatui-image image renderer with a new one I built called [`kittage`](https://github.com/itsjunetime/kittage). This supports a ton more than ratatui-image, including:
1. Sending images via shared memory objects, which is significantly faster than sending all the image data over stdout
2. Sending images without the alpha channel, which is basically always unused data with pdfs.
3. Deleting images - this isn't immediately useful, but will allow us to fix #61 once we hook it all up (i.e. delete all non-displayed images once we get an error back from the terminal that it couldn't display an image due to lack of memory)
4. Zooming/panning/all that jazz - because we have much more control over how the image is placed with kittage, this will allow us to zoom and pan and stretch and whatever *very* easily (albiet only on kitty for now) - this will finally allow us to fix #7.
5. I guess this would allow us to close #65 somewhat more easily since warp supports kitty

Things still to do:
- Add support for tmux to kittage. Hopefully this will be easier as I understand the protocol a lot better and we have a lot more control over how codes are sent
- Hook up deletion-upon-memory-exhaustion - fairly easy, I just haven't done it yet
- Make it work with windows. As of right now, the shared memory object implementation I'm using only works with unix 'cause that's the only machine I have, but I'd like to get it working windows as well. If all else fails, though, I can just not use shms on windows and just do normal direct data transfer instead.

So this isn't quite ready for prime time yet, but I'm very happy with it so far. I'm hoping to run some benchmarks soon to see if we can get numbers on the performance improvement. And who knows, if it goes well here maybe I'll try to get it into `ratatui-image` or `yazi` as their backends for displaying kitty images.