### PR TITLE
Restore Last Opened Page On Previously Opened PDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,11 +833,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -848,7 +869,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -1048,7 +1069,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs",
+ "dirs 6.0.0",
  "dwrote",
  "float-ord",
  "freetype-sys",
@@ -2616,6 +2637,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3003,6 +3035,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "csscolorparser 0.7.2",
+ "dirs 5.0.1",
  "flexi_logger",
  "flume",
  "futures-util",
@@ -3017,6 +3050,8 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "rayon",
+ "serde",
+ "serde_json",
  "tokio",
  "xflags",
 ]
@@ -3813,6 +3848,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3836,6 +3880,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3873,6 +3932,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3885,6 +3950,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3894,6 +3965,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3921,6 +3998,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3930,6 +4013,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3945,6 +4034,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3954,6 +4049,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,8 +3058,22 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "xflags",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ cbz = ["mupdf/cbz"]
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["async_tokio"] }
 cpuprofiler = "0.0.4"
+tempfile = "3.0"
 
 [[bench]]
 name = "rendering"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ rayon = { version = "*", default-features = false }
 # kittage = { path = "../kittage/", features = ["crossterm-tokio", "image-crate", "log"] }
 kittage = { git = "https://github.com/itsjunetime/kittage.git", features = ["crossterm-tokio", "image-crate", "log"] }
 memmap2 = "*"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+dirs = "5.0"
 
 # logging
 log = "0.4.27"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,37 +1,37 @@
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fs;
+use std::{collections::HashMap, fs};
+
 use dirs::config_dir;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct DocumentHistoryConfig {
-    pub last_pages_opened: HashMap<String, usize>,
+	pub last_pages_opened: HashMap<String, usize>
 }
 
 impl DocumentHistoryConfig {
-    pub fn load() -> Self {
-        if let Some(path) = Self::get_config_path() {
-            if let Ok(data) = fs::read_to_string(path) {
-                if let Ok(cfg) = serde_json::from_str(&data) {
-                    return cfg;
-                }
-            }
-        }
-        Self::default()
-    }
+	pub fn load() -> Self {
+		if let Some(path) = Self::get_config_path() {
+			if let Ok(data) = fs::read_to_string(path) {
+				if let Ok(cfg) = serde_json::from_str(&data) {
+					return cfg;
+				}
+			}
+		}
+		Self::default()
+	}
 
-    pub fn save(&self) {
-        if let Some(path) = Self::get_config_path() {
-            if let Ok(data) = serde_json::to_string_pretty(self) {
-                let _ = fs::write(path, data);
-            }
-        }
-    }
+	pub fn save(&self) {
+		if let Some(path) = Self::get_config_path() {
+			if let Ok(data) = serde_json::to_string_pretty(self) {
+				let _ = fs::write(path, data);
+			}
+		}
+	}
 
-    fn get_config_path() -> Option<std::path::PathBuf> {
-        config_dir().map(|mut dir| {
-            dir.push("tdf.config.json");
-            dir
-        })
-    }
+	fn get_config_path() -> Option<std::path::PathBuf> {
+		config_dir().map(|mut dir| {
+			dir.push("tdf.config.json");
+			dir
+		})
+	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,3 +35,132 @@ impl DocumentHistoryConfig {
 		})
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+
+	use serde_json;
+	use tempfile::tempdir;
+
+	use super::*;
+
+	#[test]
+	fn test_default_config() {
+		let config = DocumentHistoryConfig::default();
+		assert!(config.last_pages_opened.is_empty());
+	}
+
+	#[test]
+	fn test_config_serialization() {
+		let mut config = DocumentHistoryConfig::default();
+		config
+			.last_pages_opened
+			.insert("/path/to/file1.pdf".to_string(), 5);
+		config
+			.last_pages_opened
+			.insert("/path/to/file2.pdf".to_string(), 10);
+
+		let json = serde_json::to_string(&config).unwrap();
+		let deserialized: DocumentHistoryConfig = serde_json::from_str(&json).unwrap();
+
+		assert_eq!(
+			deserialized.last_pages_opened.get("/path/to/file1.pdf"),
+			Some(&5)
+		);
+		assert_eq!(
+			deserialized.last_pages_opened.get("/path/to/file2.pdf"),
+			Some(&10)
+		);
+	}
+
+	#[test]
+	fn test_config_with_temp_dir() {
+		let temp_dir = tempdir().unwrap();
+		let config_path = temp_dir.path().join("tdf.config.json");
+
+		let mut config = DocumentHistoryConfig::default();
+		config
+			.last_pages_opened
+			.insert("/test/file.pdf".to_string(), 42);
+
+		let json = serde_json::to_string_pretty(&config).unwrap();
+		fs::write(&config_path, json).unwrap();
+
+		let data = fs::read_to_string(&config_path).unwrap();
+		let loaded_config: DocumentHistoryConfig = serde_json::from_str(&data).unwrap();
+
+		assert_eq!(
+			loaded_config.last_pages_opened.get("/test/file.pdf"),
+			Some(&42)
+		);
+	}
+
+	#[test]
+	fn test_load_with_invalid_json() {
+		let temp_dir = tempdir().unwrap();
+		let config_path = temp_dir.path().join("tdf.config.json");
+
+		fs::write(&config_path, "{ invalid json }").unwrap();
+
+		let data = fs::read_to_string(&config_path).unwrap();
+		let result: Result<DocumentHistoryConfig, _> = serde_json::from_str(&data);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_config_with_empty_file() {
+		let temp_dir = tempdir().unwrap();
+		let config_path = temp_dir.path().join("tdf.config.json");
+
+		fs::write(&config_path, "").unwrap();
+
+		let data = fs::read_to_string(&config_path).unwrap();
+		let result: Result<DocumentHistoryConfig, _> = serde_json::from_str(&data);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_config_with_malformed_json() {
+		let temp_dir = tempdir().unwrap();
+		let config_path = temp_dir.path().join("tdf.config.json");
+
+		fs::write(&config_path, "{ invalid json }").unwrap();
+
+		let data = fs::read_to_string(&config_path).unwrap();
+		let result: Result<DocumentHistoryConfig, _> = serde_json::from_str(&data);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_config_save_and_load() {
+		let temp_dir = tempdir().unwrap();
+		let test_config_path = temp_dir.path().join("tdf.config.json");
+
+		let mut config = DocumentHistoryConfig::default();
+		config
+			.last_pages_opened
+			.insert("/test/file.pdf".to_string(), 123);
+
+		let json = serde_json::to_string_pretty(&config).unwrap();
+		fs::write(&test_config_path, json).unwrap();
+
+		let data = fs::read_to_string(&test_config_path).unwrap();
+		let loaded_config: DocumentHistoryConfig = serde_json::from_str(&data).unwrap();
+
+		assert_eq!(
+			loaded_config.last_pages_opened.get("/test/file.pdf"),
+			Some(&123)
+		);
+	}
+
+	#[test]
+	fn test_load_method_with_real_config() {
+		// This test verifies that the load() method works correctly
+		// It will either load an existing config or return default
+		DocumentHistoryConfig::load();
+		// The config should be valid (either loaded from file or default)
+		// We can't assert specific values since we don't know what's in the real config
+		assert!(true); // Just verify it doesn't panic
+	}
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use dirs::config_dir;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct DocumentHistoryConfig {
+    pub last_pages_opened: HashMap<String, usize>,
+}
+
+impl DocumentHistoryConfig {
+    pub fn load() -> Self {
+        if let Some(path) = Self::get_config_path() {
+            if let Ok(data) = fs::read_to_string(path) {
+                if let Ok(cfg) = serde_json::from_str(&data) {
+                    return cfg;
+                }
+            }
+        }
+        Self::default()
+    }
+
+    pub fn save(&self) {
+        if let Some(path) = Self::get_config_path() {
+            if let Ok(data) = serde_json::to_string_pretty(self) {
+                let _ = fs::write(path, data);
+            }
+        }
+    }
+
+    fn get_config_path() -> Option<std::path::PathBuf> {
+        config_dir().map(|mut dir| {
+            dir.push("tdf.config.json");
+            dir
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,12 @@ pub enum PrerenderLimit {
 	Limited(NonZeroUsize)
 }
 
+pub mod config;
 pub mod converter;
 pub mod kitty;
 pub mod renderer;
 pub mod skip;
 pub mod tui;
-pub mod config;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum FitOrFill {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod kitty;
 pub mod renderer;
 pub mod skip;
 pub mod tui;
+pub mod config;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum FitOrFill {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,11 @@ use ratatui_image::{
 };
 use tdf::{
 	PrerenderLimit,
+	config::DocumentHistoryConfig,
 	converter::{ConvertedPage, ConverterMsg, run_conversion_loop},
 	kitty::{KittyDisplay, display_kitty_images, do_shms_work, run_action},
 	renderer::{self, RenderError, RenderInfo, RenderNotif},
-	tui::{BottomMessage, InputAction, MessageSetting, Tui},
-	config::DocumentHistoryConfig
+	tui::{BottomMessage, InputAction, MessageSetting, Tui}
 };
 
 // Dummy struct for easy errors in main
@@ -80,7 +80,10 @@ async fn main() -> Result<(), WrappedErr> {
 	};
 
 	let mut document_history_config = DocumentHistoryConfig::load();
-	let path = flags.file.canonicalize().map_err(|e| WrappedErr(format!("Cannot canonicalize provided file: {e}").into()))?;
+	let path = flags
+		.file
+		.canonicalize()
+		.map_err(|e| WrappedErr(format!("Cannot canonicalize provided file: {e}").into()))?;
 
 	let black =
 		parse_color_to_i32(flags.black_color.as_deref().unwrap_or("000000")).map_err(|e| {
@@ -216,7 +219,10 @@ async fn main() -> Result<(), WrappedErr> {
 		flags.r_to_l.unwrap_or_default(),
 		is_kitty
 	);
-	if let Some(last_page) = document_history_config.last_pages_opened.get(&path.to_string_lossy().to_string()) {
+	if let Some(last_page) = document_history_config
+		.last_pages_opened
+		.get(&path.to_string_lossy().to_string())
+	{
 		tui.set_page(*last_page);
 	}
 
@@ -304,7 +310,9 @@ async fn main() -> Result<(), WrappedErr> {
 
 	drop(maybe_logger);
 
-	document_history_config.last_pages_opened.insert(path.to_string_lossy().to_string(), tui.page);
+	document_history_config
+		.last_pages_opened
+		.insert(path.to_string_lossy().to_string(), tui.page);
 	document_history_config.save();
 
 	Ok(())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -788,7 +788,7 @@ impl Tui {
 		})));
 	}
 
-	fn set_page(&mut self, page: usize) {
+	pub fn set_page(&mut self, page: usize) {
 		if page != self.page {
 			// mark that we need to re-render the images
 			self.last_render.rect = Rect::default();


### PR DESCRIPTION
# Overview

We need a way to restore the last opened page when reopening a previously opened document.

Addresses #78. 

## Problem

Often times I found myself having to remember the last page I was on when I reopened a PDF so I could navigate back to it. As you can imagine, on large PDFs this gets annoying pretty quickly.

## Solution

I opted to fix this by tracking the path of the last opened document alongside the last opened page number in a key/value fashion. This information is stored under the configuration directory of the current user (cross platform).

## Changelog

- A `DocumentHistoryConfig` struct under `config.rs` tracks the last viewed document and its page
- Basic tests for the above surrounding the above logic asserts functionality

## Demo

https://github.com/user-attachments/assets/eea6f1f5-a6ea-4e38-a52e-597f1b2e6567
