### PR TITLE
Fix macOS shared memory filename length limit (fixes issue #92)

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -142,11 +142,10 @@ pub async fn run_conversion_loop(
 					.as_millis() % 1_000_000;
 
 				let mut img = if shms_work {
-					kittage::image::Image::shm_from(
-						dyn_img,
-						&format!("tdf_{pid}_{rn}_{page_num}")
-					)
-					.map_err(|e| RenderError::Converting(format!("Couldn't write to shm: {e}")))?
+					kittage::image::Image::shm_from(dyn_img, &format!("tdf_{pid}_{rn}_{page_num}"))
+						.map_err(|e| {
+							RenderError::Converting(format!("Couldn't write to shm: {e}"))
+						})?
 				} else {
 					kittage::image::Image::from(dyn_img)
 				};

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -78,8 +78,7 @@ pub async fn run_action<'image, 'data, 'es>(
 pub async fn do_shms_work(ev_stream: &mut EventStream) -> bool {
 	let img = DynamicImage::new_rgb8(1, 1);
 	let pid = std::process::id();
-	let Ok(mut k_img) = kittage::image::Image::shm_from(img, &format!("tdf_test_{pid}"))
-	else {
+	let Ok(mut k_img) = kittage::image::Image::shm_from(img, &format!("tdf_test_{pid}")) else {
 		return false;
 	};
 


### PR DESCRIPTION
Shorten shared memory object names from "__tdf_kittage_{pid}_page_{rn}_{page_num}" to "tdf_{pid}_{rn}_{page_num}" and change timestamp from nanoseconds to milliseconds % 1M to stay under macOS's 31-character limit for shm names.

Fixes "File name too long (os error 63)" error when rendering PDFs on macOS.

On macOS, SHM_NAME_MAX: 30