### PR TITLE
Add ctrl+mousewheel zoom control for fill-screen mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tdf-viewer"
-version = "0.3.0"
+version = "0.4.2"
 dependencies = [
  "console-subscriber",
  "cpuprofiler",

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,8 @@ async fn main() -> Result<(), WrappedErr> {
 	execute!(
 		term.backend_mut(),
 		EnterAlternateScreen,
-		crossterm::cursor::Hide
+		crossterm::cursor::Hide,
+		crossterm::event::EnableMouseCapture
 	)
 	.map_err(|e| {
 		WrappedErr(
@@ -307,7 +308,8 @@ async fn main() -> Result<(), WrappedErr> {
 	execute!(
 		term.backend_mut(),
 		LeaveAlternateScreen,
-		crossterm::cursor::Show
+		crossterm::cursor::Show,
+		crossterm::event::DisableMouseCapture
 	)
 	.unwrap();
 	disable_raw_mode().unwrap();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io::stdout, num::NonZeroUsize};
 
 use crossterm::{
-	event::{Event, KeyCode, KeyModifiers, MouseEventKind},
+	event::{Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind},
 	execute,
 	terminal::{
 		BeginSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
@@ -624,7 +624,8 @@ impl Tui {
 								execute!(
 									&mut backend,
 									LeaveAlternateScreen,
-									crossterm::cursor::Show
+									crossterm::cursor::Show,
+									crossterm::event::DisableMouseCapture
 								)
 								.unwrap();
 								disable_raw_mode().unwrap();
@@ -638,7 +639,8 @@ impl Tui {
 								execute!(
 									&mut backend,
 									EnterAlternateScreen,
-									crossterm::cursor::Hide
+									crossterm::cursor::Hide,
+									crossterm::event::EnableMouseCapture
 								)
 								.unwrap();
 
@@ -754,17 +756,32 @@ impl Tui {
 					_ => None
 				}
 			}
-			Event::Mouse(mouse) => match mouse.kind {
-				MouseEventKind::ScrollRight =>
-					self.change_page(PageChange::Next, ChangeAmount::Single),
-				MouseEventKind::ScrollDown =>
-					self.change_page(PageChange::Next, ChangeAmount::WholeScreen),
-				MouseEventKind::ScrollLeft =>
-					self.change_page(PageChange::Prev, ChangeAmount::Single),
-				MouseEventKind::ScrollUp =>
-					self.change_page(PageChange::Prev, ChangeAmount::WholeScreen),
-				_ => None
-			},
+			Event::Mouse(mouse) => {
+				if mouse.modifiers.contains(KeyModifiers::CONTROL)
+					&& self.is_kitty
+					&& self.zoom.is_some()
+				{
+					match mouse.kind {
+						MouseEventKind::ScrollUp =>
+							self.update_zoom(|z| z.level = z.level.saturating_add(1).min(0)),
+						MouseEventKind::ScrollDown =>
+							self.update_zoom(|z| z.level = z.level.saturating_sub(1)),
+						_ => None
+					}
+				} else {
+					match mouse.kind {
+						MouseEventKind::ScrollRight =>
+							self.change_page(PageChange::Next, ChangeAmount::Single),
+						MouseEventKind::ScrollDown =>
+							self.change_page(PageChange::Next, ChangeAmount::WholeScreen),
+						MouseEventKind::ScrollLeft =>
+							self.change_page(PageChange::Prev, ChangeAmount::Single),
+						MouseEventKind::ScrollUp =>
+							self.change_page(PageChange::Prev, ChangeAmount::WholeScreen),
+						_ => None
+					}
+				}
+			}
 			Event::Resize(_, _) => Some(InputAction::Redraw),
 			_ => None
 		}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io::stdout, num::NonZeroUsize};
 
 use crossterm::{
-	event::{Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind},
+	event::{Event, KeyCode, KeyModifiers, MouseEventKind},
 	execute,
 	terminal::{
 		BeginSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,


### PR DESCRIPTION
  Enables mouse-based zooming; Uses ctrl+scroll up/down to
  increase/decrease zoom level while in fill-screen mode, with proper
  mouse capture handling.