### PR TITLE
Make Page-Up and Page-Down behave like up and down

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -700,9 +700,11 @@ impl Tui {
 						None
 					}
 					KeyCode::Right => self.change_page(PageChange::Next, ChangeAmount::Single),
-					KeyCode::Down => self.change_page(PageChange::Next, ChangeAmount::WholeScreen),
+					KeyCode::Down | KeyCode::PageDown =>
+						self.change_page(PageChange::Next, ChangeAmount::WholeScreen),
 					KeyCode::Left => self.change_page(PageChange::Prev, ChangeAmount::Single),
-					KeyCode::Up => self.change_page(PageChange::Prev, ChangeAmount::WholeScreen),
+					KeyCode::Up | KeyCode::PageUp =>
+						self.change_page(PageChange::Prev, ChangeAmount::WholeScreen),
 					KeyCode::Esc => match (self.showing_help_msg, &self.bottom_msg) {
 						(false, BottomMessage::Help) => Some(InputAction::QuitApp),
 						_ => {


### PR DESCRIPTION
Many presenter devices ("clickers") work by sending Page-Up and Page-Down keystrokes. Most other pdf viewers (such as firefox, chromium, zathura, okular, ...) handle these keys by advancing by a page. This PR implements this by making the two keys behave exactly like 'up' and 'down', respectively.