### PR TITLE
Implement debounce time for automatic reloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debounce"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2e5bc95e82bd8e9b333f4c5ff6dceab54e2e99f4d8cef2a680d417206ead34"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3026,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "csscolorparser 0.8.0",
+ "debounce",
  "flexi_logger",
  "flume",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ flexi_logger = "0.31"
 
 # for tracing with tokio-console
 console-subscriber = { version = "0.5.0", optional = true }
+debounce = "0.2.2"
 
 [profile.production]
 inherits = "release"


### PR DESCRIPTION
When running tdf on the output of pdflatex, one can observe
- When pdflatex truncates the output file, pages that have not yet been rewritten become blank
- pdflatex actually updates the output file so fast that tdf breaks entirely on non-trivial tex files, causing the program to just show "loading" when switching pages until it loads the file from scratch. I suspect this is coming from mupdf.

While in the case of pdflatex, this can be worked around by using the `pdflatex && mv ...` approach, other pdf viewers like zathura handle this without issue.

This PR addresses these issues using the same approach as zathura: a debounce time for file reloads. The handler for the file watcher now delays sending `RenderNotif::Reload` to the renderer until the file has stopped changing for 50ms (implemented using the `debounce` crate). This causes reloads to be capped at 20 times per second, which completely fixes the second issue.

The time can be configured via a cli option. Choosing a time around 1 second works well for pdflatex, effectively alleviating the first issue by mimicking the behavior of zathura.