### PR TITLE
Fix panic messages being printed in raw mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<(), WrappedErr> {
 async fn inner_main() -> Result<(), WrappedErr> {
 	let hook = std::panic::take_hook();
 	std::panic::set_hook(Box::new(move |info| {
+		_ = disable_raw_mode();
 		reset_term();
 		hook(info);
 	}));


### PR DESCRIPTION
While the panic hook resets the terminal to bring it out of the alternate screen, it does not disable raw mode.
On linux, which uses `\n` for newlines, text after a newline gets indented because the text cursor's column is not reset (in raw mode you need `\r\n` for this, so this probably looks fine on windows)
