### PR TITLE
Add dev utils

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.rs]
+indent_style = tab

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.mkShell {
+  nativeBuildInputs = [ pkgs.pkg-config ];
+
+  buildInputs = [
+    pkgs.cargo
+    pkgs.rustc
+    pkgs.rustPlatform.bindgenHook
+    pkgs.cairo
+    pkgs.rust-analyzer
+  ];
+}


### PR DESCRIPTION
Adds a `.editorconfig` to reflect the formatting ~~mistakes~~ choices of this project, as well as a `shell.nix` for people who hate themself.