### PR TITLE
Terminal colors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use core::{
 use std::{
 	borrow::Cow,
 	ffi::OsString,
-	io::{BufReader, Read as _, Stdout, Write as _, stdout},
+	io::{BufReader, IsTerminal as _, Read as _, Stdout, Write as _, stdout},
 	mem,
 	path::PathBuf,
 	sync::{Arc, Mutex},
@@ -130,43 +130,49 @@ async fn inner_main() -> Result<(), WrappedErr> {
 		.canonicalize()
 		.map_err(|e| WrappedErr(format!("Cannot canonicalize provided file: {e}").into()))?;
 
-	let (default_black, default_white) = if flags.terminal_colors {
+	if flags.terminal_colors && (flags.black_color.is_some() || flags.white_color.is_some()) {
+		return Err(WrappedErr(
+			"--terminal-colors cannot be combined with --black-color or --white-color".into()
+		));
+	}
+
+	let (black, white) = if flags.terminal_colors {
 		query_terminal_colors()
 	} else {
-		(MUPDF_BLACK, MUPDF_WHITE)
+		let black = flags
+			.black_color
+			.as_deref()
+			.map(|color| {
+				parse_color_to_i32(color).map_err(|e| {
+					WrappedErr(
+						format!(
+							"Couldn't parse black color {color:?}: {e} - is it formatted like a CSS color?"
+						)
+						.into()
+					)
+				})
+			})
+			.transpose()?
+			.unwrap_or(MUPDF_BLACK);
+
+		let white = flags
+			.white_color
+			.as_deref()
+			.map(|color| {
+				parse_color_to_i32(color).map_err(|e| {
+					WrappedErr(
+						format!(
+							"Couldn't parse white color {color:?}: {e} - is it formatted like a CSS color?"
+						)
+						.into()
+					)
+				})
+			})
+			.transpose()?
+			.unwrap_or(MUPDF_WHITE);
+
+		(black, white)
 	};
-
-	let black = flags
-		.black_color
-		.as_deref()
-		.map(|color| {
-			parse_color_to_i32(color).map_err(|e| {
-				WrappedErr(
-					format!(
-						"Couldn't parse black color {color:?}: {e} - is it formatted like a CSS color?"
-					)
-					.into()
-				)
-			})
-		})
-		.transpose()?
-		.unwrap_or(default_black);
-
-	let white = flags
-		.white_color
-		.as_deref()
-		.map(|color| {
-			parse_color_to_i32(color).map_err(|e| {
-				WrappedErr(
-					format!(
-						"Couldn't parse white color {color:?}: {e} - is it formatted like a CSS color?"
-					)
-					.into()
-				)
-			})
-		})
-		.transpose()?
-		.unwrap_or(default_white);
 
 	// need to keep it around throughout the lifetime of the program, but don't rly need to use it.
 	// Just need to make sure it doesn't get dropped yet.
@@ -555,42 +561,66 @@ fn parse_color_to_i32(cs: &str) -> Result<i32, csscolorparser::ParseColorError> 
 }
 
 fn query_terminal_colors() -> (i32, i32) {
+	if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+		return (MUPDF_BLACK, MUPDF_WHITE);
+	}
+
 	let Ok(()) = enable_raw_mode() else {
 		return (MUPDF_BLACK, MUPDF_WHITE);
 	};
 
-	let fg = query_osc_color(10);
-	let bg = query_osc_color(11);
+	struct RawModeGuard;
+	impl Drop for RawModeGuard {
+		fn drop(&mut self) {
+			let _ = disable_raw_mode();
+		}
+	}
+	let _guard = RawModeGuard;
 
-	let _ = disable_raw_mode();
+	let stdin = std::io::stdin();
+	let mut handle = stdin.lock();
+
+	let fg = query_osc_color(10, &mut handle);
+	let bg = query_osc_color(11, &mut handle);
+	drop(handle);
 
 	(fg.unwrap_or(MUPDF_BLACK), bg.unwrap_or(MUPDF_WHITE))
 }
 
-fn query_osc_color(osc: u8) -> Option<i32> {
+fn query_osc_color(osc: u8, handle: &mut std::io::StdinLock<'_>) -> Option<i32> {
 	print!("\x1b]{osc};?\x1b\\");
-	std::io::stdout().flush().unwrap();
+	std::io::stdout().flush().ok()?;
 
-	let stdin = std::io::stdin();
-	let mut handle = stdin.lock();
-	let mut buf = Vec::new();
+	let mut buf = Vec::with_capacity(64);
+	let mut prev = None::<u8>;
 	let mut byte = [0u8; 1];
 	loop {
 		handle.read_exact(&mut byte).ok()?;
-		if byte[0] == b'\\' || byte[0] == 0x07 {
+		let b = byte[0];
+
+		if b == 0x07 || b == 0x9c {
 			break;
 		}
-		buf.push(byte[0]);
-	}
-	drop(handle);
+		if prev == Some(0x1b) && b == b'\\' {
+			buf.pop();
+			break;
+		}
 
-	let input = String::from_utf8(buf).ok()?;
-	let rgb_str = input.split("rgb:").nth(1)?.trim_end_matches('\x1b');
+		buf.push(b);
+		prev = Some(b);
+	}
+
+	let input = core::str::from_utf8(&buf).ok()?;
+	let rgb_str = input.split("rgb:").nth(1)?;
 
 	let mut parts = rgb_str.split('/');
 	let parse = |hex: &str| -> Option<u8> {
 		let val = u16::from_str_radix(hex, 16).ok()?;
-		Some(if hex.len() <= 2 { val as u8 } else { (val >> 8) as u8 })
+		Some(if hex.len() <= 2 {
+			val as u8
+		} else {
+			(val >> 8) as u8
+		})
 	};
 
 	let r = parse(parts.next()?)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,8 @@ async fn inner_main() -> Result<(), WrappedErr> {
 		optional -w,--white-color white: String
 		/// Custom black color, specified in css format (e.g "000000" or "rgb(0, 0, 0)")
 		optional -b,--black-color black: String
+		/// Use terminal foreground/background colors for the PDF
+		optional -t,--terminal-colors
 		/// Print the version and exit
 		optional --version
 		/// PDF file to read
@@ -128,6 +130,12 @@ async fn inner_main() -> Result<(), WrappedErr> {
 		.canonicalize()
 		.map_err(|e| WrappedErr(format!("Cannot canonicalize provided file: {e}").into()))?;
 
+	let (default_black, default_white) = if flags.terminal_colors {
+		query_terminal_colors()
+	} else {
+		(MUPDF_BLACK, MUPDF_WHITE)
+	};
+
 	let black = flags
 		.black_color
 		.as_deref()
@@ -142,7 +150,7 @@ async fn inner_main() -> Result<(), WrappedErr> {
 			})
 		})
 		.transpose()?
-		.unwrap_or(MUPDF_BLACK);
+		.unwrap_or(default_black);
 
 	let white = flags
 		.white_color
@@ -158,7 +166,7 @@ async fn inner_main() -> Result<(), WrappedErr> {
 			})
 		})
 		.transpose()?
-		.unwrap_or(MUPDF_WHITE);
+		.unwrap_or(default_white);
 
 	// need to keep it around throughout the lifetime of the program, but don't rly need to use it.
 	// Just need to make sure it doesn't get dropped yet.
@@ -544,6 +552,52 @@ fn parse_color_to_i32(cs: &str) -> Result<i32, csscolorparser::ParseColorError> 
 	let color = csscolorparser::parse(cs)?;
 	let [r, g, b, _] = color.to_rgba8();
 	Ok(i32::from_be_bytes([0, r, g, b]))
+}
+
+fn query_terminal_colors() -> (i32, i32) {
+	let Ok(()) = enable_raw_mode() else {
+		return (MUPDF_BLACK, MUPDF_WHITE);
+	};
+
+	let fg = query_osc_color(10);
+	let bg = query_osc_color(11);
+
+	let _ = disable_raw_mode();
+
+	(fg.unwrap_or(MUPDF_BLACK), bg.unwrap_or(MUPDF_WHITE))
+}
+
+fn query_osc_color(osc: u8) -> Option<i32> {
+	print!("\x1b]{osc};?\x1b\\");
+	std::io::stdout().flush().unwrap();
+
+	let stdin = std::io::stdin();
+	let mut handle = stdin.lock();
+	let mut buf = Vec::new();
+	let mut byte = [0u8; 1];
+	loop {
+		handle.read_exact(&mut byte).ok()?;
+		if byte[0] == b'\\' || byte[0] == 0x07 {
+			break;
+		}
+		buf.push(byte[0]);
+	}
+	drop(handle);
+
+	let input = String::from_utf8(buf).ok()?;
+	let rgb_str = input.split("rgb:").nth(1)?.trim_end_matches('\x1b');
+
+	let mut parts = rgb_str.split('/');
+	let parse = |hex: &str| -> Option<u8> {
+		let val = u16::from_str_radix(hex, 16).ok()?;
+		Some(if hex.len() <= 2 { val as u8 } else { (val >> 8) as u8 })
+	};
+
+	let r = parse(parts.next()?)?;
+	let g = parse(parts.next()?)?;
+	let b = parse(parts.next()?)?;
+
+	Some(i32::from_be_bytes([0, r, g, b]))
 }
 
 fn get_font_size_through_stdio() -> Result<(u16, u16), WrappedErr> {


### PR DESCRIPTION
That was something useful to me - automatically picking up my terminal bg/fg colors and using those instead of manually specifying them as the command line arguments.

Now I can just run `tdf my.pdf -t` and it will render the pdf using the terminal's colors.

Not sure if this something anyone else needs, but anyways :)