### PR TITLE
Patch pathfinder_simd while upstream updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,8 +2078,7 @@ dependencies = [
 [[package]]
 name = "pathfinder_simd"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+source = "git+https://github.com/itsjunetime/pathfinder.git?branch=fix_nightly_arm_simd#814671e162a1829e074521446317b915311d3d4d"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ flexi_logger = "0.31"
 # for tracing with tokio-console
 console-subscriber = { version = "0.5.0", optional = true }
 
+[patch.crates-io]
+pathfinder_simd = { git = "https://github.com/itsjunetime/pathfinder.git", branch = "fix_nightly_arm_simd" }
+
 [profile.production]
 inherits = "release"
 lto = "fat"


### PR DESCRIPTION
While [#583] in servo/pathfiner gets merged, and `font-kit` updates its
`patfinder_simd` (and `mupdf` updates `font-kit`,) this should serve as a build
fix.

[#583]: https://github.com/servo/pathfinder/pull/583