### PR TITLE
Prevent page clear/show flash on kitty when pages have been cleared from memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added windows support! (thank you to [@jarjk](https://github.com/jarjk) for helping out!)
 - Added keybindings (`0`/`$`) to scroll to left or right side of zoomed-in image ([#131](https://github.com/itsjunetime/tdf/pull/131), thank you [@IshDeshpa](https://github.com/IshDeshpa)!)
+- Fixed issue with images clearing/flashing after displaying a certain number on kitty
 - (Internal) decreased runtime footprint of tokio runtime
 
 # v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,9 +1573,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1605,12 +1605,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -1727,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2081,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "pathfinder_simd"
 version = "0.5.5"
-source = "git+https://github.com/itsjunetime/pathfinder.git?branch=fix_nightly_arm_simd#814671e162a1829e074521446317b915311d3d4d"
+source = "git+https://github.com/itsjunetime/pathfinder.git?rev=814671e162a1829e074521446317b915311d3d4d#814671e162a1829e074521446317b915311d3d4d"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ flexi_logger = "0.31"
 console-subscriber = { version = "0.5.0", optional = true }
 
 [patch.crates-io]
-pathfinder_simd = { git = "https://github.com/itsjunetime/pathfinder.git", branch = "fix_nightly_arm_simd" }
+pathfinder_simd = { git = "https://github.com/itsjunetime/pathfinder.git", rev = "814671e162a1829e074521446317b915311d3d4d" }
 
 [profile.production]
 inherits = "release"

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -140,11 +140,12 @@ impl Display for DisplayErrSource<'_> {
 pub async fn display_kitty_images<'es>(
 	display: KittyDisplay<'_>,
 	ev_stream: &'es mut EventStream,
-	last_z_index: &mut i32,
+	last_z_index: &mut i32
 ) -> Result<(), DisplayErr<'es>> {
 	let images = match display {
 		KittyDisplay::NoChange => return Ok(()),
-		KittyDisplay::ClearImages => return run_action(
+		KittyDisplay::ClearImages =>
+			return run_action(
 				Action::Delete(DeleteConfig {
 					effect: ClearOrDelete::Clear,
 					which: WhichToDelete::All
@@ -154,7 +155,7 @@ pub async fn display_kitty_images<'es>(
 			.await
 			.map_err(|e| DisplayErr::empty("Couldn't clear previous images", e))
 			.map(|_: Option<ImageId>| ()),
-		KittyDisplay::DisplayImages(imgs) => imgs,
+		KittyDisplay::DisplayImages(imgs) => imgs
 	};
 
 	let new_z_index = last_z_index.wrapping_add_unsigned(1);
@@ -208,10 +209,11 @@ pub async fn display_kitty_images<'es>(
 				)
 				.await
 				.map_err(DisplayErrSource::Transmission)
-				.and_then(|img_id| img_id
-					.map(|id| *img = MaybeTransferred::Transferred(id))
-					.ok_or(DisplayErrSource::KittageReturnedNoId)
-				)
+				.and_then(|img_id| {
+					img_id
+						.map(|id| *img = MaybeTransferred::Transferred(id))
+						.ok_or(DisplayErrSource::KittageReturnedNoId)
+				})
 			}
 			MaybeTransferred::Transferred(image_id) => run_action(
 				Action::Display {

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -248,7 +248,7 @@ pub async fn display_kitty_images<'es>(
 		}),
 		Ok(()) => run_action(
 			Action::Delete(DeleteConfig {
-				effect: ClearOrDelete::Delete,
+				effect: ClearOrDelete::Clear,
 				which: WhichToDelete::PlacementsWithZIndex(z_idxes_to_remove)
 			}),
 			ev_stream

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -139,12 +139,12 @@ impl Display for DisplayErrSource<'_> {
 
 pub async fn display_kitty_images<'es>(
 	display: KittyDisplay<'_>,
-	ev_stream: &'es mut EventStream
+	ev_stream: &'es mut EventStream,
+	last_z_index: &mut i32,
 ) -> Result<(), DisplayErr<'es>> {
 	let images = match display {
 		KittyDisplay::NoChange => return Ok(()),
-		KittyDisplay::DisplayImages(_) | KittyDisplay::ClearImages => {
-			run_action(
+		KittyDisplay::ClearImages => return run_action(
 				Action::Delete(DeleteConfig {
 					effect: ClearOrDelete::Clear,
 					which: WhichToDelete::All
@@ -152,24 +152,23 @@ pub async fn display_kitty_images<'es>(
 				ev_stream
 			)
 			.await
-			.map_err(|e| DisplayErr::empty("Couldn't clear previous images", e))?;
-
-			let KittyDisplay::DisplayImages(images) = display else {
-				return Ok(());
-			};
-
-			images
-		}
+			.map_err(|e| DisplayErr::empty("Couldn't clear previous images", e))
+			.map(|_: Option<ImageId>| ()),
+		KittyDisplay::DisplayImages(imgs) => imgs,
 	};
+
+	let new_z_index = last_z_index.wrapping_add_unsigned(1);
 
 	let mut err = Ok::<(), (SmallVec<[usize; 2]>, DisplayErrSource<'es>)>(());
 	for KittyReadyToDisplay {
 		img,
 		page_num,
 		pos,
-		display_loc
+		mut display_loc
 	} in images
 	{
+		display_loc.z_index = new_z_index;
+
 		let config = DisplayConfig {
 			location: display_loc,
 			cursor_movement: CursorMovementPolicy::DontMove,
@@ -199,7 +198,7 @@ pub async fn display_kitty_images<'es>(
 				};
 				std::mem::swap(image, &mut fake_image);
 
-				let res = run_action(
+				run_action(
 					Action::TransmitAndDisplay {
 						image: fake_image,
 						config,
@@ -207,16 +206,12 @@ pub async fn display_kitty_images<'es>(
 					},
 					ev_stream
 				)
-				.await;
-
-				match res {
-					Ok(Some(img_id)) => {
-						*img = MaybeTransferred::Transferred(img_id);
-						Ok(())
-					}
-					Ok(None) => Err((page_num, DisplayErrSource::KittageReturnedNoId)),
-					Err(e) => Err((page_num, DisplayErrSource::Transmission(e)))
-				}
+				.await
+				.map_err(DisplayErrSource::Transmission)
+				.and_then(|img_id| img_id
+					.map(|id| *img = MaybeTransferred::Transferred(id))
+					.ok_or(DisplayErrSource::KittageReturnedNoId)
+				)
 			}
 			MaybeTransferred::Transferred(image_id) => run_action(
 				Action::Display {
@@ -229,22 +224,37 @@ pub async fn display_kitty_images<'es>(
 			.await
 			// don't need the return id 'cause we already know it
 			.map(|_: Option<ImageId>| ())
-			.map_err(|e| (page_num, DisplayErrSource::Transmission(e)))
+			.map_err(DisplayErrSource::Transmission)
 		};
 
 		log::debug!("this_err is {this_err:#?}");
 
-		if let Err((id, e)) = this_err {
+		if let Err(e) = this_err {
 			match err.as_mut() {
-				Ok(()) => err = Err((SmallVec::from([id].as_slice()), e)),
-				Err((v, _)) => v.push(id)
+				Ok(()) => err = Err((SmallVec::from([page_num].as_slice()), e)),
+				Err((v, _)) => v.push(page_num)
 			}
 		}
 	}
 
-	err.map_err(|(failed_pages, source)| DisplayErr {
-		failed_pages,
-		user_facing_err: "Couldn't transfer image to the terminal",
-		source
-	})
+	let z_idxes_to_remove = *last_z_index;
+	*last_z_index = new_z_index;
+
+	match err {
+		Err((failed_pages, source)) => Err(DisplayErr {
+			failed_pages,
+			user_facing_err: "Couldn't transfer image to the terminal",
+			source
+		}),
+		Ok(()) => run_action(
+			Action::Delete(DeleteConfig {
+				effect: ClearOrDelete::Delete,
+				which: WhichToDelete::PlacementsWithZIndex(z_idxes_to_remove)
+			}),
+			ev_stream
+		)
+		.await
+		.map_err(|e| DisplayErr::empty("Couldn't clear previously-sent images", e))
+		.map(|_| ())
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,8 @@ async fn enter_redraw_loop(
 				to_display = tui.render(f, &main_area, font_size);
 			})?;
 
-			let maybe_err = display_kitty_images(to_display, &mut ev_stream, &mut kitty_z_idx).await;
+			let maybe_err =
+				display_kitty_images(to_display, &mut ev_stream, &mut kitty_z_idx).await;
 
 			if let Err(DisplayErr {
 				failed_pages,

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,8 @@ async fn enter_redraw_loop(
 	mut main_area: tdf::tui::RenderLayout,
 	font_size: FontSize
 ) -> Result<(), Box<dyn Error>> {
+	let mut kitty_z_idx = i32::MIN;
+
 	loop {
 		let mut needs_redraw = true;
 		let next_ev = ev_stream.next().fuse();
@@ -462,7 +464,7 @@ async fn enter_redraw_loop(
 				to_display = tui.render(f, &main_area, font_size);
 			})?;
 
-			let maybe_err = display_kitty_images(to_display, &mut ev_stream).await;
+			let maybe_err = display_kitty_images(to_display, &mut ev_stream, &mut kitty_z_idx).await;
 
 			if let Err(DisplayErr {
 				failed_pages,


### PR DESCRIPTION
Kitty has a special way of displaying images to the terminal. Basically, when you transfer an image for the first time, kitty gives you back an 'id' which you can use to display that same image again. This is very useful for a program like tdf, where many of the images are repeated.

However, kitty also has some limits on how many images it'll store for you - if you send over too many images, it'll start deleting 'old' images, rendering their ids useless. So if you try to use the id of an image that was deleted, kitty will simply respond with an 'image not found'-type error, and you'll have to re-render/re-send the image to get it to actually show.

## The Issue

This caused some annoying issues with the way that we would previously display images with kitty. What we would do is:
1. Clear all previously-shown images
2. Draw new images

Pretty simple - if one of the new images failed to display (for whatever reason) there would just be a big blank slot on the UI instead of the image. This meant that whenever we encountered a deleted id, the image UI would go blank for a second due to the image not being found, then flash back into existence once it was re-rendered by our background thread.

On my machine, this process is quick enough to feel very jarring.

## The Fix

This PR changes the order of rendering to be:
1. Draw all images at a z-index of N+1
2. If all images drew successfully, clear all images that exist at a z-index of N
3. Increment stored z-index to prepare for next time

This ensures that each time we have a 'normal' sequence of events (where there are no dead ids), we still display the new images just as quickly as normal, on top of the old ones (which are then cleared after they're not visible).

However, this is a much better experience when we have dead ids. In this circumstance, the old images still stay there until the new images are ready. On my machine, this normally manifests as a very small (in the order of 100ms, if I had to wildly guess based on playing around with this for just a little bit) delay in displaying the new images each time we run into a dead id.

This is not perfectly ideal, since we still have the delay after trying to display an image, failing to do so, and having to re-render it, but it'll be much better than before.